### PR TITLE
Add missing params for Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,10 @@ class go_carbon(
   $storage_schemas          = $go_carbon::params::storage_schemas,
   $download_package         = $go_carbon::params::download_package,
   $shell                    = $go_carbon::params::shell,
+  $go_maxprocs              = $go_carbon::params::go_maxprocs,
+  $executable               = $go_carbon::params::executable,
+  $config_dir               = $go_carbon::params::config_dir,
+
 ) inherits go_carbon::params {
 
   validate_re($::osfamily, '^(RedHat|Debian)', 'This module is only supported on RHEL/CentOS 6/7 or Ubuntu 16.04')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,8 +16,6 @@ class go_carbon(
   $download_package         = $go_carbon::params::download_package,
   $shell                    = $go_carbon::params::shell,
   $go_maxprocs              = $go_carbon::params::go_maxprocs,
-  $executable               = $go_carbon::params::executable,
-  $config_dir               = $go_carbon::params::config_dir,
 
 ) inherits go_carbon::params {
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -40,7 +40,7 @@ define go_carbon::instance(
   $dump_enabled                    = $go_carbon::params::dump_enabled,
   $dump_path                       = $go_carbon::params::dump_path,
   $dump_restore_speed              = $go_carbon::params::dump_restore_speed,
-  $executable                      = $go_carbon::exectuable,
+  $executable                      = $go_carbon::executable,
   $user                            = $go_carbon::user,
   $config_dir                      = $go_carbon::config_dir,
   $go_maxprocs                     = $go_carbon::go_maxprocs,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -40,10 +40,9 @@ define go_carbon::instance(
   $dump_enabled                    = $go_carbon::params::dump_enabled,
   $dump_path                       = $go_carbon::params::dump_path,
   $dump_restore_speed              = $go_carbon::params::dump_restore_speed,
-  $executable                      = $go_carbon::executable,
-  $user                            = $go_carbon::user,
-  $config_dir                      = $go_carbon::config_dir,
-  $go_maxprocs                     = $go_carbon::go_maxprocs,
+  $executable                      = $go_carbon::params::executable,
+  $user                            = $go_carbon::params::user,
+  $config_dir                      = $go_carbon::params::config_dir,
 )
 {
   include go_carbon

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -40,6 +40,10 @@ define go_carbon::instance(
   $dump_enabled                    = $go_carbon::params::dump_enabled,
   $dump_path                       = $go_carbon::params::dump_path,
   $dump_restore_speed              = $go_carbon::params::dump_restore_speed,
+  $executable                      = $go_carbon::exectuable,
+  $user                            = $go_carbon::user,
+  $config_dir                      = $go_carbon::config_dir,
+  $go_maxprocs                     = $go_carbon::go_maxprocs,
 )
 {
   include go_carbon
@@ -97,18 +101,13 @@ define go_carbon::instance(
   validate_integer($dump_restore_speed)
 
 
-  # Put the configuration files
-  $executable = $go_carbon::executable
-  $config_dir = $go_carbon::config_dir
-  $user       = $go_carbon::user
-
   file {
-    "${go_carbon::config_dir}/${service_name}.conf":
+    "${config_dir}/${service_name}.conf":
       ensure  => $ensure,
       content => template("${module_name}/go-carbon.conf.erb")
   } ->
   go_carbon::service { $service_name: }
 
   Class[$module_name] ->
-  File["${go_carbon::config_dir}/${service_name}.conf"]
+  File["${config_dir}/${service_name}.conf"]
 }


### PR DESCRIPTION
Without these params, Puppet 4 breaks the systemd unit file as the vars are out of scope