### PR TITLE
Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class go_carbon(
   $storage_schemas          = $go_carbon::params::storage_schemas,
   $download_package         = $go_carbon::params::download_package,
   $shell                    = $go_carbon::params::shell,
+  $go_maxprocs              = $go_carbon::params::go_maxprocs,
 ) inherits go_carbon::params {
 
   validate_re($::osfamily, '^(RedHat|Debian)', 'This module is only supported on RHEL/CentOS 6/7 or Ubuntu 16.04')

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -40,6 +40,10 @@ define go_carbon::instance(
   $dump_enabled                    = $go_carbon::params::dump_enabled,
   $dump_path                       = $go_carbon::params::dump_path,
   $dump_restore_speed              = $go_carbon::params::dump_restore_speed,
+  $executable                      = $go_carbon::params::executable,
+  $config_dir                      = $go_carbon::params::config_dir,
+  $user                            = $go_carbon::params::user,
+
 )
 {
   include go_carbon
@@ -96,11 +100,6 @@ define go_carbon::instance(
   validate_absolute_path($dump_path)
   validate_integer($dump_restore_speed)
 
-
-  # Put the configuration files
-  $executable = $go_carbon::executable
-  $config_dir = $go_carbon::config_dir
-  $user       = $go_carbon::user
 
   file {
     "${go_carbon::config_dir}/${service_name}.conf":

--- a/templates/systemd.go-carbon.conf.erb
+++ b/templates/systemd.go-carbon.conf.erb
@@ -4,7 +4,7 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-Environment="GOMAXPROCS=<%= @go_maxprocs %>"
+Environment="GOMAXPROCS=<%= scope.lookupvar('go_carbon::go_maxprocs') %>"
 ExecStart=<%= @executable %> --config <%= @config_dir %>/<%= @service_name %>.conf
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process

--- a/templates/systemd.go-carbon.conf.erb
+++ b/templates/systemd.go-carbon.conf.erb
@@ -5,12 +5,12 @@ After=basic.target network.target
 
 [Service]
 Environment="GOMAXPROCS=<%= scope.lookupvar('go_carbon::go_maxprocs') %>"
-ExecStart=<%= @executable %> --config <%= @config_dir %>/<%= @service_name %>.conf
+ExecStart=<%= scope.lookupvar('go_carbon::executable') %> --config <%= scope.lookupvar('go_carbon::config_dir') %>/<%= @service_name %>.conf
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure
-User=<%= @user %>
-Group=<%= @group %>
+User=<%= scope.lookupvar('go_carbon::user') %>
+Group=<%= scope.lookupvar('go_carbon::group') %>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/upstart.go-carbon.conf.erb
+++ b/templates/upstart.go-carbon.conf.erb
@@ -16,6 +16,6 @@ stop on runlevel [06]
 # If the process quits unexpectadly trigger a respawn
 respawn
 
-env GOMAXPROCS=<%= @go_maxprocs %>
+env GOMAXPROCS=<%= scope.lookupvar('go_carbon::go_maxprocs') %>
 # Start the process
-exec <%= @executable %> --config <%= @config_dir %>/<%= @service_name %>.conf
+exec <%= scope.lookupvar('go_carbon::executable') %> --config <%= scope.lookupvar('go_carbon::config_dir') %>/<%= @service_name %>.conf


### PR DESCRIPTION
This fixes the future parser for puppet_4 compatibility:

```
--- /lib/systemd/system/go-carbon_default.service	2016-10-28 06:19:48.037827557 +0000
+++ /tmp/puppet-file20161114-26884-1gap69	2016-11-14 09:56:50.085776270 +0000
@@ -10,7 +10,7 @@
 KillMode=process
 Restart=on-failure
 User=root
-Group=
+Group=root

 [Install]
-WantedBy=multi-user.target
\ No newline at end of file
+WantedBy=multi-user.target
```

Previously doesn't look as if the group was being set correctly in systemd file either, which is fixed by this.